### PR TITLE
Fix crash if external delegate reloaded from app

### DIFF
--- a/delegate_main.cc
+++ b/delegate_main.cc
@@ -334,8 +334,7 @@ VxDelegateOptions VxDelegateOptionsDefault() {
 }
 
 TfLiteDelegate* VxDelegate() {
-  static TfLiteDelegate* delegate = vx::delegate::Delegate::Create();
-  return delegate;
+  return vx::delegate::Delegate::Create();
 }
 
 TfLiteDelegate* VxDelegateCreate(const VxDelegateOptions* options) {


### PR DESCRIPTION
Root Cause: global delegate instance deleted when external
delegate object destructed.

Signed-off-by: xiang.zhang <xiang.zhang@verisilicon.com>