### PR TITLE
modify cmake to enable external_delegate_path flags in benchmark_model

### DIFF
--- a/cmake/modules/Findtensorflow.cmake
+++ b/cmake/modules/Findtensorflow.cmake
@@ -23,7 +23,7 @@ include(FetchContent)
 FetchContent_Declare(
   tensorflow
   GIT_REPOSITORY https://github.com/tensorflow/tensorflow.git
-  GIT_TAG v2.8.0
+  GIT_TAG 936e7a1659b5a0c6ddeb1d524926f62b4c5dc5f3
 )
 FetchContent_GetProperties(tensorflow)
 if(NOT tensorflow_POPULATED)


### PR DESCRIPTION
TensorFlow 2.8.0 source code does not have the --external_delegate_path enabled for CMake, need the latest code for Tensorflow