### PR TITLE
UnidirectionalLSTM mapping

### DIFF
--- a/delegate_main.cc
+++ b/delegate_main.cc
@@ -658,6 +658,7 @@ TfLiteStatus Delegate::Invoke(const OpData& op_data,
     // TODO(derekjchow): Check result
     auto infered_input_tensor = layout_infered_.second[src_input_tensor];
     infered_input_tensor->CopyDataToTensor(const_cast<void*>(tensor_data));
+    break;  // temporary hack for sdd_lstm_int8.tflite
   }
 
   TFLITE_LOG(TFLITE_LOG_INFO, "Invoking graph");

--- a/delegate_main.cc
+++ b/delegate_main.cc
@@ -658,7 +658,6 @@ TfLiteStatus Delegate::Invoke(const OpData& op_data,
     // TODO(derekjchow): Check result
     auto infered_input_tensor = layout_infered_.second[src_input_tensor];
     infered_input_tensor->CopyDataToTensor(const_cast<void*>(tensor_data));
-    break;  // temporary hack for sdd_lstm_int8.tflite
   }
 
   TFLITE_LOG(TFLITE_LOG_INFO, "Invoking graph");

--- a/op_map.cc
+++ b/op_map.cc
@@ -280,10 +280,6 @@ struct OpMapperBase : public vx::op_map::IOpMapper {
       if (input_index < 0) {
         continue;
       }
-      // if (context->tensors[input_index].type == kTfLiteInt16) {
-      //   TFLITE_LOG_PROD(TFLITE_LOG_ERROR, "Int16 input is not supported");
-      //   return false;
-      // }
       if (context->tensors[input_index].type == kTfLiteInt64) {
         TFLITE_LOG_PROD(TFLITE_LOG_ERROR, "Int64 input is not supported");
         return false;


### PR DESCRIPTION
Limitation: Since TIM-VX doesn't have int16 implementation for ceil_state, vx-delegate insert data converter node so that lstm can be handled by NPU properly.