### PR TITLE
Fixed yolo_v4_tiny from AI-Benchmark 5.0.1 failure

### DIFF
--- a/delegate_main.cc
+++ b/delegate_main.cc
@@ -374,7 +374,7 @@ TfLiteDelegate* Delegate::Create(const VxDelegateOptions* options) {
   DerivedDelegateData* delegate = new DerivedDelegateData();
   std::memset(delegate, 0, sizeof(DerivedDelegateData));
 
-  delegate->parent.flags = kTfLiteDelegateFlagsAllowDynamicTensors;
+  delegate->parent.flags = kTfLiteDelegateFlagsAllowDynamicTensors | kTfLiteDelegateFlagsRequirePropagatedShapes;
   delegate->parent.Prepare = &PrepareDelegate;
   delegate->parent.CopyFromBufferHandle = &CopyFromBufferHandle;
   delegate->parent.FreeBufferHandle = &FreeBufferHandle;


### PR DESCRIPTION
Model require kTfLiteDelegateFlagsRequirePropagatedShapes from tflite,
original model doesn't include final shape for every tensor.

Signed-off-by: xiang.zhang <xiang.zhang@verisilicon.com>