### PR TITLE
Replace tensorflow-lite target with namespaced alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 target_link_libraries(vx_delegate ${VX_DELEGATE_DEPENDENCIES})
 add_library(vx_custom_op STATIC ${VX_CUSTOM_OP_SRCS})
 target_include_directories(vx_custom_op PUBLIC ${PROJECT_SOURCE_DIR})
-target_link_libraries(vx_custom_op tensorflow-lite)
+target_link_libraries(vx_custom_op TensorFlow::tensorflow-lite)
 add_dependencies(vx_custom_op vx_delegate)
 
 set_target_properties(benchmark_model PROPERTIES INTERFACE_LINK_LIBRARIES vx_custom_op)

--- a/cmake/modules/Findtensorflow.cmake
+++ b/cmake/modules/Findtensorflow.cmake
@@ -33,7 +33,21 @@ add_subdirectory("${tensorflow_SOURCE_DIR}/tensorflow/lite"
                  "${tensorflow_BINARY_DIR}")
 get_target_property(TFLITE_SOURCE_DIR tensorflow-lite SOURCE_DIR)
 
-add_library(TensorFlow::tensorflow-lite ALIAS tensorflow-lite)
+if(TFLITE_LIB_LOC)
+  message(STATUS "Will use prebuild tensorflow lite library from ${TFLITE_LIB_LOC}")
+  if(NOT EXISTS ${TFLITE_LIB_LOC})
+    message(FATAL_ERROR "tensorflow-lite library not found: ${TFLITE_LIB_LOC}")
+  endif()
+  add_library(TensorFlow::tensorflow-lite UNKNOWN IMPORTED)
+  set_target_properties(TensorFlow::tensorflow-lite PROPERTIES
+    IMPORTED_LOCATION ${TFLITE_LIB_LOC}
+    INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:tensorflow-lite,INTERFACE_INCLUDE_DIRECTORIES>
+  )
+  set_target_properties(tensorflow-lite PROPERTIES EXCLUDE_FROM_ALL TRUE)
+else()
+  add_library(TensorFlow::tensorflow-lite ALIAS tensorflow-lite)
+endif()
+
 
 list(APPEND VX_DELEGATE_DEPENDENCIES TensorFlow::tensorflow-lite)
 list(APPEND VX_DELEGATES_SRCS ${TFLITE_SOURCE_DIR}/tools/command_line_flags.cc)

--- a/cmake/modules/Findtensorflow.cmake
+++ b/cmake/modules/Findtensorflow.cmake
@@ -32,6 +32,10 @@ endif()
 add_subdirectory("${tensorflow_SOURCE_DIR}/tensorflow/lite"
                  "${tensorflow_BINARY_DIR}")
 get_target_property(TFLITE_SOURCE_DIR tensorflow-lite SOURCE_DIR)
-list(APPEND VX_DELEGATE_DEPENDENCIES tensorflow-lite)
+
+add_library(TensorFlow::tensorflow-lite ALIAS tensorflow-lite)
+
+list(APPEND VX_DELEGATE_DEPENDENCIES TensorFlow::tensorflow-lite)
 list(APPEND VX_DELEGATES_SRCS ${TFLITE_SOURCE_DIR}/tools/command_line_flags.cc)
 list(APPEND VX_CUSTOM_OP_SRCS ${TFLITE_SOURCE_DIR}/delegates/external/external_delegate.cc)
+

--- a/examples/minimal/CMakeLists.txt
+++ b/examples/minimal/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(minimal
   minimal.cc
 )
 target_link_libraries(minimal
-  tensorflow-lite
+  TensorFlow::tensorflow-lite
   vx_custom_op
   ${CMAKE_DL_LIBS}
 )


### PR DESCRIPTION
The PR contains 2 changes: 
**1. Replace tensorflow-lite target with namespaced alias** 
The change hides original library cmake target from TensorFlow Lite (tensorflow-lite) behind it namespaced allias. This allows the integrators to supply own FindTensorFlow.cmake file to adjust the build.  

**2. Added option to use prebuild tflite library**
Introduce a TFLITE_LIB_LOC variable. If defined this library will be used for linking (instead of building the TensorFlow Lite library again). 