### PR TITLE
Fixed Invalid write of size 4 reported by Valgrind

### DIFF
--- a/op_map.cc
+++ b/op_map.cc
@@ -2699,7 +2699,7 @@ struct ReduceOpMapper : public OpMapperBase<TfLiteReducerParams> {
     auto op =
         delegate->GetGraph()->CreateOperation<T_OperationType>(axis, keep_dims);
 
-    (*op).BindInputs(inputs);
+    (*op).BindInput(inputs[0]);
     (*op).BindOutputs(outputs);
 
     delegate->GetOps().push_back(std::move(op));


### PR DESCRIPTION
reported by Valgrind:

Invalid write of size 4
==6148==    at 0x882F2A5: tim::vx::BuiltinOpImpl::BindInput(std::shared_ptr<tim::vx::Tensor> const&) (builtin_op_impl.cc:47)
==6148==    by 0x883EBBC: tim::vx::Operation::BindInput(std::shared_ptr<tim::vx::Tensor> const&) (operation.cc:43)
==6148==    by 0x883ED5E: tim::vx::Operation::BindInputs(std::vector<std::shared_ptr<tim::vx::Tensor>, std::allocator<std::shared_ptr<tim::vx::Tensor> > > const&) (operation.cc:66)
==6148==    by 0x8143CF2: vx::op_map::ReduceOpMapper<tim::vx::ops::ReduceMean>::HandleMapOp(vx::delegate::Delegate*, std::vector<std::shared_ptr<tim::vx::Tensor>, std::allocator<std::shared_ptr<tim::vx::Tensor> > >&, std::vector<std::shared_ptr<tim::vx::Tensor>, std::allocator<std::shared_ptr<tim::vx::Tensor> > >&, void const*) (op_map.cc:2702)
==6148==    by 0x80CAA77: (anonymous namespace)::OpMapperBase<TfLiteReducerParams>::HandleMapOp(vx::delegate::Delegate*, std::vector<std::shared_ptr<tim::vx::Tensor>, std::allocator<std::shared_ptr<tim::vx::Tensor> > >&, std::vector<std::shared_ptr<tim::vx::Tensor>, std::allocator<std::shared_ptr<tim::vx::Tensor> > >&, std::vector<std::shared_ptr<tim::vx::Tensor>, std::allocator<std::shared_ptr<tim::vx::Tensor> > >&, void const*) (op_map.cc:384)
==6148==    by 0x80CAA15: (anonymous namespace)::OpMapperBase<TfLiteReducerParams>::MapOp(vx::delegate::Delegate*, std::vector<std::shared_ptr<tim::vx::Tensor>, std::allocator<std::shared_ptr<tim::vx::Tensor> > >, std::vector<std::shared_ptr<tim::vx::Tensor>, std::allocator<std::shared_ptr<tim::vx::Tensor> > >, std::vector<std::shared_ptr<tim::vx::Tensor>, std::allocator<std::shared_ptr<tim::vx::Tensor> > >, void const*) (op_map.cc:373)
==6148==    by 0x80918E1: vx::delegate::Delegate::Invoke(vx::delegate::OpData const&, TfLiteContext*, TfLiteNode*) (delegate_main.cc:636)
==6148==    by 0x808E8C2: (anonymous namespace)::DelegateNodeRegistration()::{lambda(TfLiteContext*, TfLiteNode*)#4}::operator()(TfLiteContext*, TfLiteNode*) const (delegate_main.cc:77)
==6148==    by 0x808E8E9: (anonymous namespace)::DelegateNodeRegistration()::{lambda(TfLiteContext*, TfLiteNode*)#4}::_FUN(TfLiteContext*, TfLiteNode*) (delegate_main.cc:78)
==6148==    by 0x2B3377: tflite::Subgraph::OpInvoke(TfLiteRegistration const&, TfLiteNode*) (subgraph.cc:1013)
==6148==    by 0x2B42F9: tflite::Subgraph::Invoke() (subgraph.cc:1280)
==6148==    by 0x2656EA: tflite::Interpreter::Invoke() (interpreter.cc:230)

this invalid write was fixed by this commit