### PR TITLE
Fixed wrong output shape of StridedSlice

### DIFF
--- a/op_map.cc
+++ b/op_map.cc
@@ -1182,7 +1182,7 @@ struct StridedSliceMapper : public OpMapperBase<TfLiteStridedSliceParams> {
     begin_tensor->CopyDataFromTensor(begin_dims.data());
     for (size_t i = 0; i < begin_dims.size(); i++) {
       if(begin_dims[i] < 0) {
-        begin_dims[i] += input_tensor->GetShape()[i];
+        begin_dims[i] += input_tensor->GetShape()[begin_dims.size()-1-i];
       }
       if (begin_mask & (1 << i)) {
         begin_dims[i] = -1;
@@ -1200,7 +1200,7 @@ struct StridedSliceMapper : public OpMapperBase<TfLiteStridedSliceParams> {
     end_tensor->CopyDataFromTensor(end_dims.data());
     for (size_t i = 0; i < end_dims.size(); i++) {
       if(end_dims[i] < 0) {
-        end_dims[i] += input_tensor->GetShape()[i];
+        end_dims[i] += input_tensor->GetShape()[end_dims.size()-1-i];
       }
       if (end_mask & (1 << i)) {
         end_dims[i] = end_pos;


### PR DESCRIPTION
Begin or End vector of StridedSlice were transformed to deliver to TIM-VX.
During this process, delegate generates wrong elements when met minus input, previous patch fixed the number to be positive but mismatched the position in vector, which leads to wrong output shape.

Type: Bug Fix