### PR TITLE
Fixed inputs wrong order bug in elementwise op

### DIFF
--- a/op_map.cc
+++ b/op_map.cc
@@ -433,8 +433,16 @@ struct OpMapperBase : public vx::op_map::IOpMapper {
             delegate->GetGraph()->CreateOperation<tim::vx::ops::Broadcast>(
                 broadcast_param);
         (*op_broadcast).BindInput(inputs[1-base_shape_idx]).BindOutput(broadcast_out);
-        elementwise_inputs.push_back(inputs[base_shape_idx]);
-        elementwise_inputs.push_back(broadcast_out);
+
+        if(base_shape_idx == 0){
+          elementwise_inputs.push_back(inputs[base_shape_idx]);
+          elementwise_inputs.push_back(broadcast_out);
+        }
+        else{
+          elementwise_inputs.push_back(broadcast_out);
+          elementwise_inputs.push_back(inputs[base_shape_idx]);
+        }
+
       return elementwise_inputs;
     }
     return inputs;


### PR DESCRIPTION
Keep inputs order same when base_shape input is the second input 
Type: Bug Fix
Signed-off-by: Feiyue Chen <Feiyue.Chen@verisilicon.com>