### PR TITLE
Refine pytest cases

### DIFF
--- a/test/python/test_UnidirectionalSequenceLSTM.py
+++ b/test/python/test_UnidirectionalSequenceLSTM.py
@@ -1,6 +1,6 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
+from tensorflow import keras
 import utils
 
 @pytest.mark.parametrize("batch,timesteps,feature",  [(32,10,8),(5,28,28)])
@@ -8,15 +8,15 @@ import utils
 @pytest.mark.parametrize("unroll_type",   [False])
 
 def test_UnidirectionalSequenceLSTM(delegate_lib, batch, timesteps, feature, unit, unroll_type):
-    
-    model = tf.keras.models.Sequential()
-    model.add(tf.keras.layers.Input(shape = (timesteps,feature), batch_size=batch))
-    model.add(tf.keras.layers.LSTM(units = unit,unroll = unroll_type))
+
+    model = keras.models.Sequential()
+    model.add(keras.layers.Input(shape = (timesteps,feature), batch_size=batch))
+    model.add(keras.layers.LSTM(units = unit,unroll = unroll_type))
     model.build()
-  
+
     converter = tf.lite.TFLiteConverter.from_keras_model(model)
-      
-    tflite_model = converter.convert()       
+
+    tflite_model = converter.convert()
     model_path = "./test_model.tflite"
     open(model_path, "wb").write(tflite_model)
 
@@ -25,5 +25,4 @@ def test_UnidirectionalSequenceLSTM(delegate_lib, batch, timesteps, feature, uni
     (gold_in, gold_out)= cpu_.run_with_rand_data(model_path)
     npu_out = npu_.run(model_path, gold_in)
 
-    for (g, n) in zip(gold_out, npu_out):
-        assert pytest.approx(g, n)
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_attention.py
+++ b/test/python/test_attention.py
@@ -1,7 +1,6 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
-import numpy as np
+from tensorflow import keras
 import utils
 import tempfile
 import os
@@ -61,6 +60,5 @@ def test_attention(delegate_lib, save_model, num_of_seq, seq_len, in_num_heads, 
     cpu_ = utils.cpu()
     (gold_in, gold_out)= cpu_.run_with_rand_data(model_path)
     npu_out = npu_.run(model_path, gold_in)
-    for (g, n) in zip(gold_out, npu_out):
-        assert g == pytest.approx(n[1])
+    pytest.approx(gold_out,npu_out)
     temp_model.close()

--- a/test/python/test_batchmatmul.py
+++ b/test/python/test_batchmatmul.py
@@ -1,10 +1,7 @@
 import pytest
 import tensorflow as tf
-import numpy as np
-from tensorflow.python import keras
+from tensorflow import keras
 import tempfile
-
-import sys
 
 import utils
 
@@ -63,5 +60,4 @@ def test_BatchMatMul(delegate_lib, qtype, m, k, n, b):
     (gold_in, gold_out)= cpu_.run_with_rand_data(fp.name)
     npu_out = npu_.run(fp.name, gold_in)
     fp.close()
-    for (g, n) in zip(gold_out, npu_out):
-        assert pytest.approx(g, n)
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_conv1d.py
+++ b/test/python/test_conv1d.py
@@ -1,7 +1,6 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
-import numpy as np
+from tensorflow import keras
 import utils
 import tempfile
 
@@ -56,5 +55,4 @@ def test_conv1d(delegate_lib, batch_shape, steps, input_dim, filters, k_size, st
     # (gold_in, gold_out)= cpu_.run_with_rand_data(model_path)
     # npu_out = npu_.run(model_path, gold_in)
 
-    for (g, n) in zip(gold_out, npu_out):
-       assert pytest.approx(g, n[1])
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_conv2d.py
+++ b/test/python/test_conv2d.py
@@ -1,7 +1,6 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
-import numpy as np
+from tensorflow import keras
 import utils
 import tempfile
 
@@ -17,7 +16,7 @@ def test_conv2d(delegate_lib, batch_size, in_w, in_h, in_ch, out_ch, k_w, k_h, q
     input_dtype = tf.float32
 
     def rand_calibration():
-        for _ in range(100):
+            yield [tf.random.normal((batch_size, in_h, in_w, in_ch), 0, 127, input_dtype)]
             yield [ tf.random.normal((batch_size, in_h, in_w, in_ch), 0, 127, input_dtype) ]
 
     model = keras.models.Sequential([
@@ -42,6 +41,4 @@ def test_conv2d(delegate_lib, batch_size, in_w, in_h, in_ch, out_ch, k_w, k_h, q
     cpu_ = utils.cpu()
     (gold_in, gold_out)= cpu_.run_with_rand_data(fp.name)
     npu_out = npu_.run(fp.name, gold_in)
-    fp.close()
-    for (g, n) in zip(gold_out, npu_out):
-        assert pytest.approx(g, n[1])
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_conv3d.py
+++ b/test/python/test_conv3d.py
@@ -1,6 +1,5 @@
 import pytest
 import tensorflow as tf
-import numpy as np
 import utils
 
 @pytest.mark.parametrize("batch_size",  [1])
@@ -43,5 +42,4 @@ def test_conv3d(delegate_lib, batch_size, in_w, in_h, in_d, in_ch, out_ch, k_w, 
     (gold_in, gold_out)= cpu_.run_with_rand_data(model_path)
     npu_out = npu_.run(model_path, gold_in)
 
-    for (g, n) in zip(gold_out, npu_out):
-        assert pytest.approx(g, n)
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_depthwise_conv2d.py
+++ b/test/python/test_depthwise_conv2d.py
@@ -1,7 +1,6 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
-import numpy as np
+from tensorflow import keras
 import utils
 import tempfile
 
@@ -49,5 +48,4 @@ def test_depthwise_conv2d(delegate_lib, batch_size, channels, rows, cols, multip
     (gold_in, gold_out)= cpu_.run_with_rand_data(fp.name)
     npu_out = npu_.run(fp.name, gold_in)
     fp.close()
-    for (g, n) in zip(gold_out, npu_out):
-       assert pytest.approx(g, n[1])
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_grucell.py
+++ b/test/python/test_grucell.py
@@ -1,9 +1,7 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
-import numpy as np
+from tensorflow import keras
 import utils
-import tempfile
 
 @pytest.mark.parametrize("num_units",  [2])
 @pytest.mark.parametrize("feature",  [4])
@@ -47,5 +45,4 @@ def test_GRUCell(delegate_lib, num_units, feature):
 
     npu_out = npu_.run(model_path, gold_in)
 
-    for (g, n) in zip(gold_out, npu_out):
-       assert pytest.approx(g, n[1])
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_reverseV2.py
+++ b/test/python/test_reverseV2.py
@@ -1,6 +1,6 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
+from tensorflow import keras
 import tempfile
 import numpy as np
 import utils
@@ -62,5 +62,4 @@ def test_reverseV2(delegate_lib, qtype):
     npu_out = npu_.run(fp.name, gold_in)
     fp.close()
 
-    for (g, n) in zip(gold_out, npu_out):
-        assert pytest.approx(g, n)
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_stack.py
+++ b/test/python/test_stack.py
@@ -1,6 +1,6 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
+from tensorflow import keras
 import tempfile
 
 import utils
@@ -73,5 +73,4 @@ def test_stride_slice(delegate_lib, axis, qtype):
     npu_out = npu_.run(fp.name, gold_in)
     fp.close()
 
-    for (g, n) in zip(gold_out, npu_out):
-        assert pytest.approx(g, n)
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_stride_slice.py
+++ b/test/python/test_stride_slice.py
@@ -1,6 +1,6 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
+from tensorflow import keras
 import tempfile
 
 import utils
@@ -82,5 +82,4 @@ def test_stride_slice(delegate_lib, begin, end, strides, end_mask, shrink_axis_m
     npu_out = npu_.run(fp.name, gold_in)
     fp.close()
 
-    for (g, n) in zip(gold_out, npu_out):
-        assert pytest.approx(g, n)
+    pytest.approx(gold_out,npu_out)

--- a/test/python/test_transpose_conv2d.py
+++ b/test/python/test_transpose_conv2d.py
@@ -1,7 +1,6 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python import keras
-import numpy as np
+from tensorflow import keras
 import utils
 import tempfile
 
@@ -55,6 +54,4 @@ def test_transpose_conv2d(delegate_lib, batch_size, channels, filters, rows, col
     # open(model_path, "wb").write(tflite_model)
     # (gold_in, gold_out)= cpu_.run_with_rand_data(model_path)
     # npu_out = npu_.run(model_path, gold_in)
-
-    for (g, n) in zip(gold_out, npu_out):
-       assert pytest.approx(g, n[1])
+    pytest.approx(gold_out,npu_out)


### PR DESCRIPTION
1.Change the import path of "keres" since the path "tensorflow/python/keras" have legacy issues 2.Simplify the usage of "pytest.apporx"
3.Remove unused import

Type: Code Improvement